### PR TITLE
Remove unhealthy servers from stats page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,15 @@ This repo contains:
 
 ## Running Stats App Locally
 
+With local registry:
+
 1. Start [openrvs-registry](https://github.com/willroberts/openrvs-registry) locally
-2. Start the stats app (`go run main.go` or `build.bat; stats.exe`)
+2. Start the stats app with `go run *.go`
+3. Visit http://localhost:8081 in your browser to get stats as JSON
+
+With remote registry:
+
+2. Start the stats app with `go run *.go -registry-url https://openrvs.org/servers`
 3. Visit http://localhost:8081 in your browser to get stats as JSON
 
 ## Testing Frontend Locally

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ With local registry:
 
 1. Start [openrvs-registry](https://github.com/willroberts/openrvs-registry) locally
 2. Start the stats app with `go run *.go`
-3. Visit http://localhost:8081 in your browser to get stats as JSON
+3. Visit http://localhost:8081/stats.json in your browser
 
 With remote registry:
 
 2. Start the stats app with `go run *.go -registry-url https://openrvs.org/servers`
-3. Visit http://localhost:8081 in your browser to get stats as JSON
+3. Visit http://localhost:8081/stats.json in your browser
 
 ## Testing Frontend Locally
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var (
 	defaultRegistryURL = "http://127.0.0.1:8080/servers"
 
 	beaconTimeout  = 5 * time.Second
-	beaconInterval = 15 * time.Second
+	beaconInterval = 10 * time.Second
 
 	FriendlyGameModes = map[string]string{
 		"RGM_BombAdvMode":           "Bomb",
@@ -83,12 +83,12 @@ func pollServers() {
 				if info.CurrentPlayers > 0 {
 					newServers = append(newServers, info)
 				}
+				wg.Done()
 			}(hp)
 		}
 		wg.Wait()
 
 		// Rebuild server cache.
 		Servers = newServers
-		log.Println("server info updated")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -2,17 +2,20 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"log"
 	"net/http"
 	"sync"
 	"time"
 )
 
-const RegistryURL = "http://127.0.0.1:8080/servers"
-
 var (
-	beaconTimeout     = 5 * time.Second
-	beaconInterval    = 15 * time.Second
+	registryURL        string
+	defaultRegistryURL = "http://127.0.0.1:8080/servers"
+
+	beaconTimeout  = 5 * time.Second
+	beaconInterval = 15 * time.Second
+
 	FriendlyGameModes = map[string]string{
 		"RGM_BombAdvMode":           "Bomb",
 		"RGM_DeathmatchMode":        "Survival",
@@ -23,10 +26,15 @@ var (
 		"RGM_TeamDeathmatchMode":    "Team Survival",
 		"RGM_TerroristHuntCoopMode": "Terrorist Hunt",
 	}
+
+	// Global server cache.
+	Servers = make([]ServerInfo, 0)
 )
 
-// Global server cache.
-var Servers = make([]ServerInfo, 0)
+func init() {
+	flag.StringVar(&registryURL, "registry-url", defaultRegistryURL, "Full URL for openrvs-registry")
+	flag.Parse()
+}
 
 func main() {
 	go pollServers()

--- a/registry.go
+++ b/registry.go
@@ -13,8 +13,8 @@ type HostPort struct {
 	Port int
 }
 
-// Retrieves healthy servers from openrvs-registry.
-func getHostPorts() ([]HostPort, error) {
+// Retrieves healthy servers from openrvs-registry over HTTP.
+func getServersFromRegistry() ([]HostPort, error) {
 	var hostports = make([]HostPort, 0)
 	resp, err := http.Get(RegistryURL)
 	if err != nil {

--- a/registry.go
+++ b/registry.go
@@ -16,7 +16,7 @@ type HostPort struct {
 // Retrieves healthy servers from openrvs-registry over HTTP.
 func getServersFromRegistry() ([]HostPort, error) {
 	var hostports = make([]HostPort, 0)
-	resp, err := http.Get(RegistryURL)
+	resp, err := http.Get(registryURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Rebuilds the server cache from registry instead of selectively updating the cache, which helps prune unhealthy servers
- Reduces refresh interval from 15s to 10s
- Allows configurable registry URL
- Fixes a fast failure loop when registry is unavailable
- Updates docs